### PR TITLE
fix(ci): react-hooks/refs lint in dialog exit freeze

### DIFF
--- a/components/credential-dialog.tsx
+++ b/components/credential-dialog.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 import { AlertTriangle, Check, Copy } from "lucide-react"
 import { Button, Label, Modal } from "@heroui/react"
 import Pdf417Barcode from "@/components/pdf417-barcode"
@@ -52,24 +52,25 @@ export function CredentialDialog({ credential, onClose }: { credential: Credenti
   const open = !!credential
   const [mounted, setMounted] = useState(open)
   const [visible, setVisible] = useState(open)
-  const dataRef = useRef<Credential | null>(credential)
-
-  if (credential) dataRef.current = credential
+  const [frozen, setFrozen] = useState<Credential | null>(credential)
 
   useEffect(() => {
-    if (open) {
+    if (open && credential) {
+      setFrozen(credential)
       setMounted(true)
       const id = requestAnimationFrame(() => setVisible(true))
       return () => cancelAnimationFrame(id)
     }
+
     setVisible(false)
     const t = window.setTimeout(() => setMounted(false), EXIT_MS)
     return () => window.clearTimeout(t)
-  }, [open])
+  }, [open, credential])
 
-  if (!mounted || !dataRef.current) return null
+  if (!mounted) return null
 
-  const data = dataRef.current
+  const data = open ? credential : frozen
+  if (!data) return null
 
   return (
     <Modal.Backdrop

--- a/components/dashboard/inventory-table.tsx
+++ b/components/dashboard/inventory-table.tsx
@@ -32,7 +32,6 @@ import {
   Edit,
   Trash2,
   Minus,
-  Filter,
   Download,
   Search,
 } from "lucide-react"

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -4,6 +4,8 @@ import * as React from "react"
 import { Button, Modal } from "@heroui/react"
 import { cn } from "@/lib/utils"
 
+const EXIT_MS = 280
+
 type Ctx = { open: boolean; setOpen: (open: boolean) => void }
 const AlertDialogContext = React.createContext<Ctx | null>(null)
 
@@ -66,18 +68,15 @@ function AlertDialogOverlay() {
   return null
 }
 
-const EXIT_MS = 280
-
 function AlertDialogContent({ className, children, ...props }: React.HTMLAttributes<HTMLDivElement>) {
   const { open, setOpen } = useAlertDialogCtx()
   const [mounted, setMounted] = React.useState(open)
   const [visible, setVisible] = React.useState(open)
-  const contentRef = React.useRef(children)
-
-  if (open) contentRef.current = children
+  const [frozenChildren, setFrozenChildren] = React.useState(children)
 
   React.useEffect(() => {
     if (open) {
+      setFrozenChildren(children)
       setMounted(true)
       const id = requestAnimationFrame(() => setVisible(true))
       return () => cancelAnimationFrame(id)
@@ -85,7 +84,7 @@ function AlertDialogContent({ className, children, ...props }: React.HTMLAttribu
     setVisible(false)
     const t = window.setTimeout(() => setMounted(false), EXIT_MS)
     return () => window.clearTimeout(t)
-  }, [open])
+  }, [open, children])
 
   if (!mounted) return null
 
@@ -102,7 +101,7 @@ function AlertDialogContent({ className, children, ...props }: React.HTMLAttribu
           className={cn("dialog-panel-motion sm:max-w-md", className)}
           {...(props as Record<string, unknown>)}
         >
-          {contentRef.current}
+          {open ? children : frozenChildren}
         </Modal.Dialog>
       </Modal.Container>
     </Modal.Backdrop>

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -110,15 +110,13 @@ function DialogContent({ className, children, ...props }: React.HTMLAttributes<H
   const { open, setOpen } = useDialogCtx()
   const [mounted, setMounted] = React.useState(open)
   const [visible, setVisible] = React.useState(open)
-  const contentRef = React.useRef(children)
-
-  // Keep last open content so close animation still has body/footer
-  if (open) {
-    contentRef.current = children
-  }
+  // Freeze last open children in state (not ref) so close animation keeps content
+  // and react-hooks/refs lint stays clean.
+  const [frozenChildren, setFrozenChildren] = React.useState(children)
 
   React.useEffect(() => {
     if (open) {
+      setFrozenChildren(children)
       setMounted(true)
       const id = requestAnimationFrame(() => setVisible(true))
       return () => cancelAnimationFrame(id)
@@ -127,11 +125,12 @@ function DialogContent({ className, children, ...props }: React.HTMLAttributes<H
     setVisible(false)
     const t = window.setTimeout(() => setMounted(false), EXIT_MS)
     return () => window.clearTimeout(t)
-  }, [open])
+  }, [open, children])
 
   if (!mounted) return null
 
-  const childArray = React.Children.toArray(contentRef.current)
+  const rendered = open ? children : frozenChildren
+  const childArray = React.Children.toArray(rendered)
   const footers = childArray.filter(isDialogFooter)
   const rest = childArray.filter((child) => !isDialogFooter(child))
 


### PR DESCRIPTION
## Summary
- **Root cause:** job `web-and-rules` failed at `npm run lint` with **14× `react-hooks/refs` errors**.
- Exit-animation freeze used `useRef` written/read during render in:
  - `components/ui/dialog.tsx`
  - `components/ui/alert-dialog.tsx`
  - `components/credential-dialog.tsx`
- **Fix:** freeze last open content with `useState` + `useEffect` (no ref access during render). Close animation still holds content ~280ms.
- Also remove unused `Filter` import in inventory table.

## Verification
- Local: `npm run lint` → **0 errors** (warnings only, pre-existing)
- Local: `npm run typecheck` OK

## Test plan
- [ ] CI `web-and-rules` green
- [ ] Open/close Detail/Edit dialogs still smooth
- [ ] Credential dialog close still smooth

Refs: https://github.com/drybrine/webinvesp32/actions/runs/30034230050/job/89297991517

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dialog and credential prompt closing animations by preserving displayed content during transitions.
  - Prevented dialog content from changing unexpectedly while a close animation is in progress.
  - Improved consistency when dialog content or credentials update as the dialog opens and closes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->